### PR TITLE
fixed typo in description of needle in haystack

### DIFF
--- a/Misc/needle_in_haystack/README.md
+++ b/Misc/needle_in_haystack/README.md
@@ -21,7 +21,7 @@ The pattern is:
 - 1 number between 2 and 7
 - 1 number between 1 and 5
 
-I remember key number 0 and 1 were c0f21 and c0f22 respectively.
+I remember key number 0 and 1 were c0ff21 and c0ff22 respectively.
 
 and the correct key today is key number 585937
 

--- a/Misc/needle_in_haystack/challenge.yml
+++ b/Misc/needle_in_haystack/challenge.yml
@@ -22,7 +22,7 @@ description: >
   - 1 number between 2 and 7
   - 1 number between 1 and 5
 
-  I remember key number 0 and 1 were c0f21 and c0f22 respectively.
+  I remember key number 0 and 1 were c0ff21 and c0ff22 respectively.
 
   and the correct key today is key number 585937
 

--- a/Misc/needle_in_haystack/writeup/README.md
+++ b/Misc/needle_in_haystack/writeup/README.md
@@ -19,7 +19,7 @@
 > - 1 number between 2 and 7
 > - 1 number between 1 and 5
 >
-> I remember key number 0 and 1 were c0f21 and c0f22 respectively.
+> I remember key number 0 and 1 were c0ff21 and c0ff22 respectively.
 >
 > and the correct key today is key number 585937
 


### PR DESCRIPTION
there was a missing character in the example in the description

"c0f21 and c0f22" --> "c0ff21 and c0ff22"